### PR TITLE
doc: added provider's organization_id option

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -84,6 +84,7 @@ Use `pulumi config set scaleway:<option>` or pass options to the [constructor of
 |-----|------|------|----|
 | `access_key`| `SCW_ACCESS_KEY` | Required | [Scaleway access key](https://console.scaleway.com/project/credentials) |
 | `secret_key`| `SCW_SECRET_KEY` | Required | [Scaleway secret key](https://console.scaleway.com/project/credentials) |
+| `organization_id` | `SCW_ORGANIZATION_ID` | Required | The [organization ID](https://console.scaleway.com/organization) that will be used as default value for all resources. |
 | `project_id` | `SCW_DEFAULT_PROJECT_ID` | Required | The [project ID](https://console.scaleway.com/project/settings) that will be used as default value for all resources. |
 | `region` | `SCW_DEFAULT_REGION` | Optional | The [region](https://registry.terraform.io/providers/scaleway/scaleway/latest/guides/regions_and_zones#regions) that will be used as default value for all resources. (`fr-par` if none specified) |
 | `zone` | `SCW_DEFAULT_ZONE` | Optional | The [zone](https://registry.terraform.io/providers/scaleway/scaleway/latest/guides/regions_and_zones#zones) that will be used as default value for all resources. (`fr-par-1` if none specified)


### PR DESCRIPTION
I wanted to force an organization ID on all my projects since my user has access to multiple orgs. I though the provider didn't have the option since it wasn't documented, but apparently it does ! Adding this missing piece of doc. 

Maybe it was left out voluntarily since other configs exists on Provider and are not documented, but I thought this one was common enough to be worth appearing. I can add doc for other configs if needed.