### PR TITLE
Upgrade terraform-provider-scaleway to v2.60.2

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -176,7 +176,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250721082157-a9b7a7bd9686 // indirect
-	github.com/scaleway/terraform-provider-scaleway/v2 v2.60.1 // indirect
+	github.com/scaleway/terraform-provider-scaleway/v2 v2.60.2 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2284,8 +2284,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9Am
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250721082157-a9b7a7bd9686 h1:rSbtkU5fMMXbv0qwIH5dBq+TvAYnbClahwPP1KtN9bs=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250721082157-a9b7a7bd9686/go.mod h1:fw6BmcfYRs2BEHYW0c3/rR0JgZHvdx6uMYqpeUJx3Bc=
-github.com/scaleway/terraform-provider-scaleway/v2 v2.60.1 h1:b79b0hWZ1DCCVGiWHUKEeD2/zE6q+6wJlxKrv8HEYDM=
-github.com/scaleway/terraform-provider-scaleway/v2 v2.60.1/go.mod h1:LcyenRSggxZOQdhP0g2yQKd8OxGgvWTBBH4RlG0eyd8=
+github.com/scaleway/terraform-provider-scaleway/v2 v2.60.2 h1:YwWZFOGJ4E9nyZH3bLzyJr37IC2HN1ry01/TzV3Wx/I=
+github.com/scaleway/terraform-provider-scaleway/v2 v2.60.2/go.mod h1:LcyenRSggxZOQdhP0g2yQKd8OxGgvWTBBH4RlG0eyd8=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
-	github.com/scaleway/terraform-provider-scaleway/v2 v2.60.1
+	github.com/scaleway/terraform-provider-scaleway/v2 v2.60.2
 )
 
 require (

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -230,8 +230,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250721082157-a9b7a7bd9686 h1:rSbtkU5fMMXbv0qwIH5dBq+TvAYnbClahwPP1KtN9bs=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250721082157-a9b7a7bd9686/go.mod h1:fw6BmcfYRs2BEHYW0c3/rR0JgZHvdx6uMYqpeUJx3Bc=
-github.com/scaleway/terraform-provider-scaleway/v2 v2.60.1 h1:b79b0hWZ1DCCVGiWHUKEeD2/zE6q+6wJlxKrv8HEYDM=
-github.com/scaleway/terraform-provider-scaleway/v2 v2.60.1/go.mod h1:LcyenRSggxZOQdhP0g2yQKd8OxGgvWTBBH4RlG0eyd8=
+github.com/scaleway/terraform-provider-scaleway/v2 v2.60.2 h1:YwWZFOGJ4E9nyZH3bLzyJr37IC2HN1ry01/TzV3Wx/I=
+github.com/scaleway/terraform-provider-scaleway/v2 v2.60.2/go.mod h1:LcyenRSggxZOQdhP0g2yQKd8OxGgvWTBBH4RlG0eyd8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-scaleway --kind=provider --target-bridge-version=latest --target-version=2.60.2 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-scaleway from 2.60.1  to 2.60.2.
	Fixes #443
